### PR TITLE
Fix Spotify subheader typo

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ with tab2:
 
 with tab3:
         st.header("All Platform Stats")
-        st.subheader("Spotfiy")
+        st.subheader("Spotify")
                 
         c1, c2= st.columns(2)
         c3, c4= st.columns(2)


### PR DESCRIPTION
## Summary
- correct a typo in the Spotify subheader in `main.py`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68446bdd3db88323844569e8dd2fd1bf